### PR TITLE
Update readme.md with correct link to build guide.

### DIFF
--- a/Keyboards/2% Milk/readme.md
+++ b/Keyboards/2% Milk/readme.md
@@ -1,6 +1,6 @@
 # 2% Milk keyboard
 ![2%Milk](https://i.imgur.com/Ud96uXn.png)
-### [Build Guide](https://spaceboards.xyz/2milkbuild)
+### [Build Guide](https://spaceboards.xyz/hardware/2milkbuild)
 
 
 ### Credits
@@ -8,4 +8,5 @@
 - PCB made by PyroL
 
 ### Updates
+- 1/27/21 WRONG LINK TO BUILD GUIDE.  UPDATED WITH CORRECT LINK.
 - 8/22/19 WRONG FILE WAS UPLOADED EARLIER. USB PORT PLACEMENT WAS INCORRECT. CORRECT FILE HAS BEEN UPLOADED. 


### PR DESCRIPTION
The link to the build guide is 404'd.  I visited https://spaceboards.xyz/hardware to get the correct link.

I made assumptions about the Updates section.  Please remove that line if it's not required.